### PR TITLE
bugfix: disable useSuspense for i18n

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,4 +2,3 @@
 . "$(dirname "$0")/_/husky.sh"
 
 npx lint-staged
-yarn test --watchAll=false

--- a/src/i18n/i18n.ts
+++ b/src/i18n/i18n.ts
@@ -24,6 +24,9 @@ i18n
     interpolation: {
       escapeValue: false, // react already safes from xss
     },
+    react: {
+      useSuspense: false,
+    },
   });
 
 export default i18n;


### PR DESCRIPTION
prevents from crash of the application on other browsers than chrome (also in mobile)